### PR TITLE
Use Folia region scheduler for command block sessions

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockCommandSender.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockCommandSender.java
@@ -37,6 +37,7 @@ import org.bukkit.command.BlockCommandSender;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -191,18 +192,14 @@ public class BukkitBlockCommandSender extends AbstractCommandBlockActor {
 
             @Override
             public boolean isActive() {
-                if (Bukkit.isPrimaryThread()) {
+                Block block = sender.getBlock();
+                if (Bukkit.getRegionScheduler().isCurrentThread(block.getLocation())) {
                     // we can update eagerly
                     updateActive();
                 } else {
                     // we should update it eventually
-                    Bukkit.getScheduler().callSyncMethod(
-                            plugin,
-                            () -> {
-                                updateActive();
-                                return null;
-                            }
-                    );
+                    CompletableFuture<?> future = Bukkit.getGlobalRegionScheduler().execute(plugin, block.getLocation(), () -> updateActive());
+                    // CompletableFuture result ignored; task scheduled for later execution
                 }
                 return active;
             }


### PR DESCRIPTION
## Summary
- Replace deprecated callSyncMethod with Folia's region scheduler, returning a CompletableFuture
- Use RegionScheduler#isCurrentThread instead of Bukkit.isPrimaryThread
- Schedule command block activity checks via global region scheduler

## Testing
- `./gradlew :worldedit-bukkit:test` *(fails: Task with name 'build' not found in project ':worldedit-libs:cli')*

------
https://chatgpt.com/codex/tasks/task_e_68be09c28330833197cc1d86e303c6c7